### PR TITLE
macOS: bump target to macOS 10.10

### DIFF
--- a/Makefile.macOS
+++ b/Makefile.macOS
@@ -149,7 +149,7 @@ SHARED_BUILD	= 1
 INCLUDES	=  -I"./generic" -I"./macosx" -I"/Library/Frameworks/Tcl.framework/Headers" -I"/Library/Frameworks/Tcl.framework/PrivateHeaders" -I"/Users/culler/TclTk/tcl9.0/generic" -I"/Users/culler/TclTk/tcl9.0/unix" -I"/Library/Frameworks/Tk.framework/Headers" -I"/Library/Frameworks/Tk.framework/PrivateHeaders" -I"/Users/culler/TclTk/tk9.0/generic" -I"/Users/culler/TclTk/tk9.0/unix" -I"/Users/culler/TclTk/tk9.0/generic/ttk" -I""/Users/culler/TclTk/tk9.0/xlib"" -I"/Users/culler/TclTk/tk9.0/macosx" -I.
 #INCLUDES	=  -I"./generic" -I"./macosx" -I"/Library/Frameworks/Tcl.framework/Headers" -I"/Library/Frameworks/Tcl.framework/PrivateHeaders" -I"/Users/culler/TclTk/tcl9.0/generic" -I"/Users/culler/TclTk/tcl9.0/unix" -I"/Library/Frameworks/Tk.framework/Headers" -I"/Library/Frameworks/Tk.framework/PrivateHeaders" -I"/Users/culler/TclTk/tk9.0/generic" -I"/Users/culler/TclTk/tk9.0/unix" -I"/Users/culler/TclTk/tk9.0/generic/ttk" -I""/Users/culler/TclTk/tk9.0/xlib"" -I"/Users/culler/TclTk/tk9.0/macosx" 
 
-PKG_CFLAGS	=   -x objective-c -mmacosx-version-min=10.9 -arch x86_64 -arch arm64 -Wno-deprecated-declarations
+PKG_CFLAGS	=   -x objective-c -mmacosx-version-min=10.10 -arch x86_64 -arch arm64 -Wno-deprecated-declarations
 
 # TCL_DEFS is not strictly need here, but if you remove it, then you
 # must make sure that configure.ac checks for the necessary components
@@ -164,7 +164,7 @@ CONFIG_CLEAN_FILES = Makefile pkgIndex.tcl
 CLEANFILES	= 
 
 CPPFLAGS	= 
-LIBS		=  -arch x86_64 -arch arm64 -mmacosx-version-min=10.9 -lobjc -framework OpenGL -framework AppKit 
+LIBS		=  -arch x86_64 -arch arm64 -mmacosx-version-min=10.10 -lobjc -framework OpenGL -framework AppKit
 AR		= ar
 CFLAGS		= -pipe  ${CFLAGS_DEFAULT} ${CFLAGS_WARNING} ${SHLIB_CFLAGS}  
 LDFLAGS		=  -headerpad_max_install_names -Wl,-search_paths_first 

--- a/ci/linux/linux_configure
+++ b/ci/linux/linux_configure
@@ -5420,7 +5420,7 @@ else
         # On macOS, compile Tkgl source files as objective C because they need
         # access to the OpenGL framework and the NSView class.
 
-    PKG_CFLAGS="$PKG_CFLAGS -x objective-c -mmacosx-version-min=10.9"
+    PKG_CFLAGS="$PKG_CFLAGS -x objective-c -mmacosx-version-min=10.10"
 
 
 
@@ -5434,7 +5434,7 @@ else
 
 	# Really these should go in LDFLAGS but tcl.m4 is lame.
 
-    vars="-arch x86_64 -arch arm64 -mmacosx-version-min=10.9"
+    vars="-arch x86_64 -arch arm64 -mmacosx-version-min=10.10"
     for i in $vars; do
 	if test "${TEA_PLATFORM}" = "windows" -a "$GCC" = "yes" ; then
 	    # Convert foo.lib to -lfoo for GCC.  No-op if not *.lib

--- a/ci/macOS/build_mac_tkgl.sh
+++ b/ci/macOS/build_mac_tkgl.sh
@@ -37,27 +37,27 @@ autoconf
 
 echo "Building Tcl 8"
 cd tcl8
-make -j4 -C macosx CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.9" deploy
+make -j4 -C macosx CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.10" deploy
 echo "Building Tk 8"
 cd ../tk8
-make -j4 -C macosx CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.9" deploy
+make -j4 -C macosx CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.10" deploy
 cd ..
 mv build build8
 echo "Building TkGL for Tcl/Tk 8"
 ./configure --with-tcl=build8/tcl/Tcl.framework --with-tk=build8/tk/Tk.framework
-make CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.9"
+make CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.10"
 mv libTkgl*.dylib dist/Tkgl$TKGL_VERSION
 echo "Building Tcl 9"
 cd tcl9
-make -j4 -C macosx CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.9" deploy
+make -j4 -C macosx CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.10" deploy
 echo "Building Tk 9"
 cd ../tk9/
-make -j4 -C macosx CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.9" deploy
+make -j4 -C macosx CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.10" deploy
 cd ..
 mv build build9
 pwd
 ls
 ./configure --with-tcl=build9/tcl/Tcl.framework --with-tk=build9/tk/Tk.framework
-make CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.9"
+make CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=10.10"
 mv *.dylib dist/Tkgl$TKGL_VERSION
 mv pkgIndex.tcl dist/Tkgl$TKGL_VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -107,12 +107,12 @@ else
         TEA_ADD_INCLUDES([-I\"${srcdir}/macosx\"])
         # On macOS, compile Tkgl source files as objective C because they need
         # access to the OpenGL framework and the NSView class.
-        TEA_ADD_CFLAGS([-x objective-c -mmacosx-version-min=10.9])
+        TEA_ADD_CFLAGS([-x objective-c -mmacosx-version-min=10.10])
         TEA_ADD_CFLAGS([-arch x86_64 -arch arm64])
         # Apple has deprecated OpenGL.  We don't need to hear about it:
         TEA_ADD_CFLAGS([-Wno-deprecated-declarations])
 	# Really these should go in LDFLAGS but tcl.m4 is lame.
-        TEA_ADD_LIBS([-arch x86_64 -arch arm64 -mmacosx-version-min=10.9])
+        TEA_ADD_LIBS([-arch x86_64 -arch arm64 -mmacosx-version-min=10.10])
         TEA_ADD_LIBS([-lobjc -framework OpenGL -framework AppKit])
     fi
 fi


### PR DESCRIPTION
Hello! It's me again.

Building TkGL on macOS throws a warning when run with the flag `-Wunguarded-availability`. (I ran into this when including TkGL as part of the [Nixpkgs](https://hydra.nixos.org/build/318200344/nixlog/1) project.)

I think the problem is in [this line](https://github.com/3-manifolds/TkGL/blob/45bf16e6c28a070c70fc9a0eb8c47a0b6ff8a2e3/macosx/tkglNSOpenGL.c#L115): the variable [NSOpenGLProfileVersion4_1Core](
https://developer.apple.com/documentation/appkit/nsopenglprofileversion4_1core) was introduced in macOS 10.10.

Please let me know if I am missing a reason for the current minimum version being 10.9.